### PR TITLE
encode utf-8 characters properly before writing to csv

### DIFF
--- a/es2csv.py
+++ b/es2csv.py
@@ -209,7 +209,9 @@ class Es2csv:
                 for line in open(self.tmp_file, 'r'):
                     timer += 1
                     bar.update(timer)
-                    csv_writer.writerow(json.loads(line))
+                    line_as_dict = json.loads(line)
+                    line_dict_utf8 = {k: v.encode('utf8') if isinstance(v, unicode) else v for k, v in line_as_dict.items()}
+                    csv_writer.writerow(line_dict_utf8)
                 output_file.close()
                 bar.finish()
             else:


### PR DESCRIPTION
My log lines contained non-ascii characters and newlines, which ES returned as (unicode) escape sequences. These need to be encoded.
Fix taken from http://stackoverflow.com/questions/5838605/python-dictwriter-writing-utf-8-encoded-csv-files