### PR TITLE
better progressbar unit names

### DIFF
--- a/es2csv.py
+++ b/es2csv.py
@@ -126,7 +126,7 @@ class Es2csv:
                        progressbar.Percentage(),
                        progressbar.FormatLabel('] [%(elapsed)s] ['),
                        progressbar.ETA(), '] [',
-                       progressbar.FileTransferSpeed(), ']'
+                       progressbar.FileTransferSpeed('docs'), ']'
                        ]
             bar = progressbar.ProgressBar(widgets=widgets, maxval=self.num_results).start()
 
@@ -202,7 +202,7 @@ class Es2csv:
                            progressbar.Percentage(),
                            progressbar.FormatLabel('] [%(elapsed)s] ['),
                            progressbar.ETA(), '] [',
-                           progressbar.FileTransferSpeed(), ']'
+                           progressbar.FileTransferSpeed('lines'), ']'
                            ]
                 bar = progressbar.ProgressBar(widgets=widgets, maxval=self.num_results).start()
 


### PR DESCRIPTION
The default "byte" was misleading.