### PR TITLE
Add explicit authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ Usage
   -q, --query QUERY                        Query string in Lucene syntax.               [required]
   -o, --output_file FILE                   CSV file location.                           [required]
   -u, --url URL                            Elasticsearch host URL. Default is http://localhost:9200.
+  -a, --auth                               Elasticsearch basic authentication in the form of username:password.
   -i, --index-prefixes INDEX [INDEX ...]   Index name prefix(es). Default is ['logstash-*'].
   -t, --tags TAGS [TAGS ...]               Query tags.
   -f, --fields FIELDS [FIELDS ...]         List of selected fields in output. Default is ['_all'].
@@ -45,7 +46,6 @@ Usage
   -k, --kibana_nested                      Format nested fields in Kibana style.
   -r, --raw_query                          Switch query format in the Query DSL.
   -e, --meta_fields                        Add meta-fields in output.
-  -a, --auth                               Elasticsearch basic authentication in the form of username:password.
   -v, --version                            Show version and exit.
   --debug                                  Debug mode on.
   -h, --help                               show this help message and exit

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Usage
   -k, --kibana_nested                      Format nested fields in Kibana style.
   -r, --raw_query                          Switch query format in the Query DSL.
   -e, --meta_fields                        Add meta-fields in output.
+  -a, --auth                               Elasticsearch basic authentication in the form of username:password.
   -v, --version                            Show version and exit.
   --debug                                  Debug mode on.
   -h, --help                               show this help message and exit
@@ -104,6 +105,12 @@ With Authorization
 .. code-block:: bash
 
   $ es2csv -u http://login:password@my.cool.host.com:6666/es/ -q 'host: localhost' -o database.csv
+
+With explicit Authorization
+
+.. code-block:: bash
+
+  $ es2csv -u http://my.cool.host.com:6666/es/ -q 'host: localhost' -o database.csv -a login:password
   
 Specifying index
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Usage
 -----
 .. code-block:: bash
 
- $ es2csv [-h] -q QUERY [-u URL] [-i INDEX [INDEX ...]]
+ $ es2csv [-h] -q QUERY [-u URL] [-a AUTH] [-i INDEX [INDEX ...]]
           [-t TAGS [TAGS ...]] -o FILE [-f FIELDS [FIELDS ...]]
           [-d DELIMITER] [-m INTEGER] [-k] [-r] [-v] [--debug]
 
@@ -110,7 +110,7 @@ With explicit Authorization
 
 .. code-block:: bash
 
-  $ es2csv -u http://my.cool.host.com:6666/es/ -q 'host: localhost' -o database.csv -a login:password
+  $ es2csv -a login:password -u http://my.cool.host.com:6666/es/ -q 'host: localhost' -o database.csv 
   
 Specifying index
 

--- a/es2csv.py
+++ b/es2csv.py
@@ -255,6 +255,7 @@ def main():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument('-q', '--query', dest='query', type=str, required=True, help='Query string in Lucene syntax.')
     p.add_argument('-u', '--url', dest='url', default='http://localhost:9200', type=str, help='Elasticsearch host URL. Default is %(default)s.')
+    p.add_argument('-a', '--auth', dest='auth', type=str, required=False, help='Elasticsearch basic authentication in the form of username:password.')
     p.add_argument('-i', '--index-prefixes', dest='index_prefixes', default=['logstash-*'], type=str, nargs='+', metavar='INDEX', help='Index name prefix(es). Default is %(default)s.')
     p.add_argument('-t', '--tags', dest='tags', type=str, nargs='+', help='Query tags.')
     p.add_argument('-o', '--output_file', dest='output_file', type=str, required=True, metavar='FILE', help='CSV file location.')
@@ -264,7 +265,6 @@ def main():
     p.add_argument('-k', '--kibana_nested', dest='kibana_nested', action='store_true', help='Format nested fields in Kibana style.')
     p.add_argument('-r', '--raw_query', dest='raw_query', action='store_true', help='Switch query format in the Query DSL.')
     p.add_argument('-e', '--meta_fields', dest='meta_fields', action='store_true', help='Add meta-fields in output.')
-    p.add_argument('-a', '--auth', dest='auth', type=str, required=False, help='Elasticsearch basic authentication in the form of username:password.')
     p.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Show version and exit.')
     p.add_argument('--debug', dest='debug_mode', action='store_true', help='Debug mode on.')
 

--- a/es2csv.py
+++ b/es2csv.py
@@ -264,7 +264,7 @@ def main():
     p.add_argument('-k', '--kibana_nested', dest='kibana_nested', action='store_true', help='Format nested fields in Kibana style.')
     p.add_argument('-r', '--raw_query', dest='raw_query', action='store_true', help='Switch query format in the Query DSL.')
     p.add_argument('-e', '--meta_fields', dest='meta_fields', action='store_true', help='Add meta-fields in output.')
-    p.add_argument('-a', '--auth', dest='auth', type=str, required=False, help='Elastic search basic authentication in the form of username:password')
+    p.add_argument('-a', '--auth', dest='auth', type=str, required=False, help='Elasticsearch basic authentication in the form of username:password.')
     p.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Show version and exit.')
     p.add_argument('--debug', dest='debug_mode', action='store_true', help='Debug mode on.')
 

--- a/es2csv.py
+++ b/es2csv.py
@@ -71,7 +71,7 @@ class Es2csv:
 
     @retry(elasticsearch.exceptions.ConnectionError, tries=TIMES_TO_TRY)
     def create_connection(self):
-        es = elasticsearch.Elasticsearch(self.opts.url, timeout=CONNECTION_TIMEOUT)
+        es = elasticsearch.Elasticsearch(self.opts.url, timeout=CONNECTION_TIMEOUT, http_auth=self.opts.auth)
         es.cluster.health()
         self.es_conn = es
 
@@ -264,6 +264,7 @@ def main():
     p.add_argument('-k', '--kibana_nested', dest='kibana_nested', action='store_true', help='Format nested fields in Kibana style.')
     p.add_argument('-r', '--raw_query', dest='raw_query', action='store_true', help='Switch query format in the Query DSL.')
     p.add_argument('-e', '--meta_fields', dest='meta_fields', action='store_true', help='Add meta-fields in output.')
+    p.add_argument('-a', '--auth', dest='auth', type=str, required=False, help='Elastic search basic authentication in the form of username:password')
     p.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Show version and exit.')
     p.add_argument('--debug', dest='debug_mode', action='store_true', help='Debug mode on.')
 


### PR DESCRIPTION
Hi,

I created this pull request because I ran into the following issue, documented here: 

https://github.com/elastic/elasticsearch-py/issues/470#issuecomment-256091032

It appears that python does not like the have hash signs in passwords when using the recommended  RFC-1738. So, for example, a password like "myPassword#" will break authentication with ES. 

This PR adds the following: 
- Option -a or --auth for authentication 

Elasticsearch will prefer RFC-style auth when both are specified. I could be convinced to add validation for this case (where both are specified). This version does not have that as I saw it unnecessary for my purposes :) 

Let me know your thoughts! 

-- Artur 
