### PR TITLE
Added --csvquoting(-c) argument for specifying CSV quoting type

### DIFF
--- a/es2csv.py
+++ b/es2csv.py
@@ -223,7 +223,7 @@ class Es2csv:
             if self.num_results > 0:
                 self.csv_headers.sort()
                 output_file = open(self.opts.output_file, 'a')
-                csv_writer = csv.DictWriter(output_file, fieldnames=self.csv_headers, delimiter=self.opts.delimiter)
+                csv_writer = csv.DictWriter(output_file, fieldnames=self.csv_headers, delimiter=self.opts.delimiter, quoting=getattr(csv,self.opts.csvquoting))
                 csv_writer.writeheader()
                 timer = 0
                 widgets = ['Write to csv ',
@@ -266,6 +266,7 @@ def main():
     p.add_argument('-o', '--output_file', dest='output_file', type=str, required=True, metavar='FILE', help='CSV file location.')
     p.add_argument('-f', '--fields', dest='fields', default=['_all'], type=str, nargs='+', help='List of selected fields in output. Default is %(default)s.')
     p.add_argument('-d', '--delimiter', dest='delimiter', default=',', type=str, help='Delimiter to use in CSV file. Default is "%(default)s".')
+    p.add_argument('-c', '--csvquoting', dest='csvquoting', default='QUOTE_NONE', type=str, help='Quote type to use in CSV file. Default is "%(default)s".')
     p.add_argument('-m', '--max', dest='max_results', default=0, type=int, metavar='INTEGER', help='Maximum number of results to return. Default is %(default)s.')
     p.add_argument('-k', '--kibana_nested', dest='kibana_nested', action='store_true', help='Format nested fields in Kibana style.')
     p.add_argument('-r', '--raw_query', dest='raw_query', action='store_true', help='Switch query format in the Query DSL.')


### PR DESCRIPTION
This option adds the quoting type for the csv.DictWriter. Defaults to csv.QUOTE_NONE