### PR TITLE
add optional "kibana style" delimiter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,8 @@ Usage
  $ es2csv [-h] -q QUERY [-u URL] [-a AUTH] [-i INDEX [INDEX ...]]
           [-D DOC_TYPE [DOC_TYPE ...]] [-t TAGS [TAGS ...]] -o FILE
           [-f FIELDS [FIELDS ...]] [-S FIELDS [FIELDS ...]] [-d DELIMITER]
-          [-m INTEGER] [-s INTEGER] [-k] [-r] [-e] [--verify-certs]
-          [--ca-certs CA_CERTS] [--client-cert CLIENT_CERT]
+          [-m INTEGER] [-s INTEGER] [-k] [-kd KIBANA_DELIMITER] [-r] [-e]
+          [--verify-certs] [--ca-certs CA_CERTS] [--client-cert CLIENT_CERT]
           [--client-key CLIENT_KEY] [-v] [--debug]
 
  Arguments:
@@ -56,6 +56,7 @@ Usage
   -m, --max INTEGER                        Maximum number of results to return. Default is 0.
   -s, --scroll-size INTEGER                Scroll size for each batch of results. Default is 100.
   -k, --kibana-nested                      Format nested fields in Kibana style.
+  -kd, --kibana-delimiter                  Optional delimiter for Kibana style.
   -r, --raw-query                          Switch query format in the Query DSL.
   -e, --meta-fields                        Add meta-fields in output.
   --verify-certs                           Verify SSL certificates. Default is False.

--- a/es2csv.py
+++ b/es2csv.py
@@ -192,7 +192,7 @@ class Es2csv:
                 if header not in self.csv_headers:
                     self.csv_headers.append(header)
                 try:
-                    out[header] = '{}{}{}'.format(out[header], self.opts.delimiter, source)
+                    out[header] = '{}{}{}'.format(out[header], self.opts.kibana_delimiter, source)
                 except:
                     out[header] = source
 

--- a/es2csv_cli.py
+++ b/es2csv_cli.py
@@ -33,6 +33,7 @@ def main():
     p.add_argument('-m', '--max', dest='max_results', default=0, type=int, metavar='INTEGER', help='Maximum number of results to return. Default is %(default)s.')
     p.add_argument('-s', '--scroll-size', dest='scroll_size', default=100, type=int, metavar='INTEGER', help='Scroll size for each batch of results. Default is %(default)s.')
     p.add_argument('-k', '--kibana-nested', dest='kibana_nested', action='store_true', help='Format nested fields in Kibana style.')
+    p.add_argument('-kd', '--kibana-delimiter', dest='kibana_delimiter', type=str, required=False, default=',', help='Delimiter for Kibana Style')
     p.add_argument('-r', '--raw-query', dest='raw_query', action='store_true', help='Switch query format in the Query DSL.')
     p.add_argument('-e', '--meta-fields', dest='meta_fields', action='store_true', help='Add meta-fields in output.')
     p.add_argument('--verify-certs', dest='verify_certs', action='store_true', help='Verify SSL certificates. Default is %(default)s.')


### PR DESCRIPTION
Adds optional delimiter when writing as "Kibana style".  Where this formerly would default to a comma `,`, this would provide a runtime parameter `-kd` or `--kibana-delimiter` that would accept a character to use for multivalued cells.

Addresses: https://github.com/taraslayshchuk/es2csv/issues/61

Wholly understand if doesn't fit the library, was a pretty quick hack for our purposes, but thought a PR couldn't hurt.  Thanks for a great and useful library.