### PR TITLE
Added --fix-header option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Usage
           [-m INTEGER] [-s INTEGER] [-k] [-r] [-e] [--verify-certs]
           [--ca-certs CA_CERTS] [--client-cert CLIENT_CERT]
           [--client-key CLIENT_KEY] [-v] [--debug]
+          [--fix-header]
 
  Arguments:
   -q, --query QUERY                        Query string in Lucene syntax.               [required]
@@ -64,6 +65,7 @@ Usage
   --client-key CLIENT_KEY                  Location of Client Cert Key.
   -v, --version                            Show version and exit.
   --debug                                  Debug mode on.
+  --fix-header                             Replace . with _ and remove @ in the output csv header row.
   -h, --help                               show this help message and exit
 
 [ `Usage Examples <./docs/EXAMPLES.rst>`_ | `Release Changelog <./docs/HISTORY.rst>`_ ]

--- a/es2csv.py
+++ b/es2csv.py
@@ -172,6 +172,10 @@ class Es2csv:
 
     def flush_to_file(self, hit_list):
         def to_keyvalue_pairs(source, ancestors=[], header_delimeter='.'):
+            # Use _ for Oracle database
+            if self.opts.fix_header == True:
+                header_delimeter = '_'
+                
             def is_list(arg):
                 return type(arg) is list
 
@@ -188,7 +192,12 @@ class Es2csv:
                 else:
                     [to_keyvalue_pairs(item, ancestors + [str(index)]) for index, item in enumerate(source)]
             else:
-                header = header_delimeter.join(ancestors)
+                # Remove @ sign from ES's metadata column heads
+                if self.opts.fix_header == True:
+                    header = header_delimeter.join(ancestors).replace('@', '')
+                else:
+                    header = header_delimeter.join(ancestors)
+
                 if header not in self.csv_headers:
                     self.csv_headers.append(header)
                 try:

--- a/es2csv_cli.py
+++ b/es2csv_cli.py
@@ -41,6 +41,7 @@ def main():
     p.add_argument('--client-key', dest='client_key', default=None, type=str, help='Location of Client Cert Key.')
     p.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Show version and exit.')
     p.add_argument('--debug', dest='debug_mode', action='store_true', help='Debug mode on.')
+    p.add_argument('--fix-header', dest='fix_header', action='store_true', help='Replace . to _ and remove @ in the header row.')
 
     if len(sys.argv) == 1:
         p.print_help()


### PR DESCRIPTION
Dot and At signs are usually reserved symbols in database systems. 
Added an option as --fix-header to explicitly do 2 things for the output csv header row:
1. Replace dot with underscore;
2. Remove all the @s which are from the metadata columns.
