### PR TITLE
Request and store es version info and use to modify the object select…

### DIFF
--- a/es2csv.py
+++ b/es2csv.py
@@ -6,6 +6,7 @@ import elasticsearch
 import progressbar
 from backports import csv
 from functools import wraps
+from packaging import version
 
 
 FLUSH_BUFFER = 1000  # Chunk of docs to flush in temp file
@@ -61,6 +62,7 @@ class Es2csv:
                                          client_cert=self.opts.client_cert, client_key=self.opts.client_key)
         es.cluster.health()
         self.es_conn = es
+        self.es_info = es.info()
 
     @retry(elasticsearch.exceptions.ConnectionError, tries=TIMES_TO_TRY)
     def check_indexes(self):
@@ -124,7 +126,14 @@ class Es2csv:
             print('Sorting by: {}.'.format(', '.join(self.opts.sort)))
 
         res = self.es_conn.search(**search_args)
-        self.num_results = res['hits']['total']
+
+# Breaking change in ES 7.0 for total hits
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response
+
+        if version.parse(self.es_info['version']['number']) < version.parse("7.0.0"):
+            self.num_results = res['hits']['total']
+        else:
+            self.num_results = res['hits']['total']['value']
 
         print('Found {} results.'.format(self.num_results))
         if self.opts.debug_mode:


### PR DESCRIPTION
This is a proposed fix for Issue #74 in which the a breaking change in ES 7.0 modified the structure of the object containing the number of hits. 

This change requests and stores the ES info object which is later used by the packaging.version() routine to make a choice on how to retrieve the number of hits from the ES query. This enables backwards compatibility with ES instances older than 7.0.
