### PR TITLE
fit some change for es7.x

### DIFF
--- a/es2csv.py
+++ b/es2csv.py
@@ -124,7 +124,7 @@ class Es2csv:
             print('Sorting by: {}.'.format(', '.join(self.opts.sort)))
 
         res = self.es_conn.search(**search_args)
-        self.num_results = res['hits']['total']
+        self.num_results = res['hits']['total']['value']
 
         print('Found {} results.'.format(self.num_results))
         if self.opts.debug_mode:
@@ -234,6 +234,7 @@ class Es2csv:
 
     def clean_scroll_ids(self):
         try:
-            self.es_conn.clear_scroll(body=','.join(self.scroll_ids))
+            for sid in self.scroll_ids:
+                self.es_conn.clear_scroll(scroll_id=sid))
         except:
             pass


### PR DESCRIPTION
when i use es2scv for es7.5, i find two problems, first one is that searchResult struct has changed, and second is important i guess, scroll clear api in es7.x official documents shows scroll_id set in body, but actually it not work fine, but set in url param is ok.